### PR TITLE
feat/revenue-component

### DIFF
--- a/apps/frontend/src/modules/home/components/todays-revenue.jsx
+++ b/apps/frontend/src/modules/home/components/todays-revenue.jsx
@@ -1,0 +1,16 @@
+export function TodaysRevenue({ revenue }) {
+  const formattedRevenue =
+    typeof revenue === 'number'
+      ? revenue.toLocaleString('en-US', {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })
+      : 'Invalid Revenue';
+
+  return (
+    <div className="p-6 m-2 bg-white shadow rounded-md w-full">
+      <h2 className="text-lg font-semibold text-gray-700">Today's Revenue</h2>
+      <p className="text-2xl font-bold">Php{formattedRevenue}</p>
+    </div>
+  );
+}

--- a/apps/frontend/src/modules/home/pages/home-page.jsx
+++ b/apps/frontend/src/modules/home/pages/home-page.jsx
@@ -1,6 +1,7 @@
 import { usePing } from '@/modules/home/hooks/use-ping';
 import { useEffect } from 'react';
 import { Link } from 'react-router';
+import { TodaysRevenue } from '../components/todays-revenue';
 
 export function HomePage() {
   const { ping, status } = usePing();
@@ -16,6 +17,10 @@ export function HomePage() {
       <Link to="/sample" className="underline mt-10 text-center">
         Go to Sample Page
       </Link>
+
+      <div className="flex items-center justify-center ">
+        <TodaysRevenue revenue={50000} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Added component revenue that accepts props for the actual revenue.

- Automatically add decimal points if non provided
- Automatically add comma
- Only accept number data type

## Issue Reference
#16
Fixes #ISSUE_NUMBER

> Use keywords to link/mark an issue, see https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
